### PR TITLE
Lost exception in device initialization

### DIFF
--- a/lib/src/Device.dart
+++ b/lib/src/Device.dart
@@ -153,7 +153,11 @@ Future<Device> _doWhenDeviceReady(String serviceUri) {
     if (ready) {
       //call/register the device-ready callback
       if (_deviceReady())
-        _doDeviceReady();
+        try {
+          _doDeviceReady();
+        } catch (exp) {
+          cmpl.completeException(exp);
+        }
       else
         _addEventListener("deviceready", _doDeviceReady, true);
     } else //time out, throw exception.


### PR DESCRIPTION
If function _doDeviceReady failed with exception, Future not catch it.
