### PR TITLE
package js deprecated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,3 +14,8 @@
 
    * Refactor 'device' out from Rikulo main trunk.
    * Make it run with Dart's official js-interop package and independent to Rikulo's code.
+
+* Sep. 3, 2014
+
+   * js-interop is deprecated, must specify version 0.2.0.
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,11 @@ authors:
 - Henri Chen <henrichen@rikulo.org>
 - Tom Yeh <tomyeh@rikulo.org>
 homepage: http://rikulo.org
-dependencies:
-  js: any
+#dependencies:
+#  js: any
+dependency_overrides:
+  js: 0.2.0
+
 dev_dependencies:
   unittest: any
 environment:


### PR DESCRIPTION
Version 0.3.0 of the package dart-lang/js-interop is a breaking change - all the code was removed to prevent use. This change specifies use of version 0.2.0, the version that js-interop is now frozen at.

Reference https://github.com/dart-lang/js-interop/issues/151

Bruce
