### PR TITLE
Init even if "deviceready" was already called

### DIFF
--- a/lib/src/device/Device.dart
+++ b/lib/src/device/Device.dart
@@ -57,7 +57,10 @@ class Device {
     };
     
     //Essential to any application. It signals that Cordova's device APIs have loaded and are ready to access.
-    document.addEventListener("deviceready", doWhenDeviceReady);
+    if (js.context['device'] == null)
+	    document.addEventListener("deviceready", doWhenDeviceReady);
+    else
+	    doWhenDeviceReady('');
     return cmpl.future;
   }
 }


### PR DESCRIPTION
Successfully init even if "deviceready" was already called from outside of rikulo/gap.
